### PR TITLE
fix: youtube command

### DIFF
--- a/src/commands/youtube.ts
+++ b/src/commands/youtube.ts
@@ -1,6 +1,10 @@
-import { getConfig } from '../config';
-import { Command } from '../types';
 import fetch from 'node-fetch';
+
+import { getConfig } from '../config';
+import type { Command } from '../types';
+
+const isErrorResponse = (response: YoutubeResponse): response is YoutubeResponseError =>
+  'error' in response;
 
 const youtube: Command = {
   name: 'youtube',
@@ -12,39 +16,53 @@ const youtube: Command = {
     const result = await fetch(
       `https://www.googleapis.com/youtube/v3/search?part=id&type=video&key=${YOUTUBE_API_KEY}&q=${query}`,
     );
-    const data = (await result.json()) as YoutubeResponse;
+    const response = (await result.json()) as YoutubeResponse;
 
-    if (!data.items.length) {
+    if (isErrorResponse(response)) {
+      return msg.channel.send(`Uh, integracja z API YT nie zadziałała 😭`);
+    }
+
+    if (!response.items.length) {
       return msg.channel.send(`Niestety nic nie znalazłam 😭`);
     }
 
-    const { videoId } = data.items[0].id;
+    const [
+      {
+        id: { videoId },
+      },
+    ] = response.items;
     return msg.channel.send(`https://www.youtube.com/watch?v=${videoId}`);
   },
 };
 
 export default youtube;
 
-interface YoutubeResponse {
-  kind: string;
-  etag: string;
-  nextPageToken: string;
-  regionCode: string;
-  pageInfo: PageInfo;
-  items: YoutubeItem[];
+interface YoutubeResponseError {
+  readonly error: unknown;
+}
+
+interface YoutubeResponseSuccess {
+  readonly kind: string;
+  readonly etag: string;
+  readonly nextPageToken: string;
+  readonly regionCode: string;
+  readonly pageInfo: PageInfo;
+  readonly items: ReadonlyArray<YoutubeItem>;
 }
 
 interface PageInfo {
-  totalResults: number;
-  resultsPerPage: number;
+  readonly totalResults: number;
+  readonly resultsPerPage: number;
 }
 
 interface YoutubeItem {
-  kind: string;
-  etag: string;
-  id: YoutubeItemId;
+  readonly kind: string;
+  readonly etag: string;
+  readonly id: YoutubeItemId;
 }
 interface YoutubeItemId {
-  kind: string;
-  videoId: string;
+  readonly kind: string;
+  readonly videoId: string;
 }
+
+type YoutubeResponse = YoutubeResponseSuccess | YoutubeResponseError;


### PR DESCRIPTION
## Why the integration is failing at all?

Most probably, since there are no logs, there are 2 scenarios:

1. API key got revoked
2. There are no sufficient permissions for usage of YT API.

## Solution
Create new API key if needed, or use existing one - they are managable be changed at Google console for project that was used to generate the key under `credentials`.

Make sure there are `none` application restrictions, or you put server IP address on allow list.
![Screenshot 2022-01-26 at 00 22 52](https://user-images.githubusercontent.com/6861120/151077762-d0a6e278-5fbb-4ab4-84c7-fbfbffbae6d3.png)

## Test

I run it with my own Google Cloud project, where I enabled YT API with `none` application restrictions.
It works like a charm 
![Screenshot 2022-01-26 at 00 20 35](https://user-images.githubusercontent.com/6861120/151077284-a5c728dd-7f8f-4cce-be9a-d150fbd516eb.png)

## Changes in code
Changes in code are rather cosmetic - just to catch and distinguish errors from YT API next time.